### PR TITLE
Add Custom video streamer

### DIFF
--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Typography, Grid } from '@mui/material';
+
+const VIDEO_SRC = "https://thebigmouth-media.s3.eu-west-2.amazonaws.com/public/multimedia/longer_movie.mp4"
+
+export default function VideoPlayer() {
+    const [currentTime, setCurrentTime] = useState(0);
+    const [duration, setDuration] = useState(0);
+
+    useEffect(() => {
+        const videoElement = document.getElementById('video-active');
+        const onTimeUpdate = (event) => {
+            setCurrentTime(videoElement.currentTime);
+            setDuration(videoElement.duration);
+        };
+        videoElement.addEventListener('timeupdate', onTimeUpdate);
+        return () => {
+          // Cleanup: remove the event listener when the component is unmounted
+          videoElement.removeEventListener('timeupdate', onTimeUpdate);
+        };
+      }, []); // The empty dependency array ensures that the effect runs only once, similar to componentDidMount
+
+  return (
+    <Grid container sx={{display: 'flex', flexDirection: 'column'}}>
+    <Typography>Currrent Time: {currentTime}</Typography>
+    <Typography>Duration Time: {duration}</Typography>
+    <video
+        id="video-active"
+        width="640"
+        height="390"
+        controls="controls"
+        src={VIDEO_SRC}
+       / >
+    </Grid>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import Error from "./pages/ErrorPage";
 import Multimedia from "./pages/MultimediaPage";
 import Profile from "./pages/ProfilePage";
 import DummyHomePage from "./pages/DummyHomePage";
-
+import VideoPlayer from "./components/VideoPlayer";
 import Theme from "./theme";
 import App from "./App";
 
@@ -63,6 +63,7 @@ root.render(
               <Route path="Dashboard" element={<Dashboard />}></Route>
               <Route path="profile" element={<Profile />} />
               <Route path="*" element={<Error />} />
+              <Route path="videoplayer" element={<VideoPlayer/>} />
             </Route>
           </Routes>
         </BrowserRouter>


### PR DESCRIPTION
This PR is a proof of concept of the XRAY vision. When we play a video, we can print off the current timestamp of the video. 

It also is a POC for video streaming from S3. The video natively streams instead of downloading. 


To test, go to the path /videoplayer and click play. 