### PR TITLE
Updated NavBar Links

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -21,11 +21,11 @@ const pages = [
   "HOME",
   "ABOUT US",
   "THEATRE",
-  "GET INVOLVED",
   "TBH MEANS BUSINESS",
   "THE BIG MOUTH",
+  "VIDEOHUB",
 ];
-const settingsLogin = ["Profile"];
+const settingsLogin = ["Profile", "Dashboard"];
 function NavBar() {
   const navigate = useNavigate();
   const { user, isAuthenticated } = useAuth0();
@@ -89,7 +89,13 @@ function NavBar() {
               color="inherit"
               sx={{ ml: 2, mr: 2 }}
             >
-              <SearchIcon />
+              <SearchIcon
+                onClick={() =>
+                  alert(
+                    "This section is currently under development. Please take a look at THE BIG MOUTH, VIDEOHUB pages and the USER environment as well."
+                  )
+                }
+              />
             </IconButton>
             <IconButton
               size="large"
@@ -127,11 +133,25 @@ function NavBar() {
               {pages.map((page) => (
                 <MenuItem key={page} onClick={handleCloseNavMenu}>
                   <Typography
-                    onClick={() =>
-                      navigate(
-                        page === "HOME" || page === "THE BIG MOUTH" ? "/" : "#"
-                      )
-                    }
+                    onClick={() => {
+                      if (
+                        page === "ABOUT US" ||
+                        page === "THEATRE" ||
+                        page === "TBH MEANS BUSINESS"
+                      ) {
+                        alert(
+                          "This section is currently under development. Please take a look at THE BIG MOUTH, VIDEOHUB pages, and the USER environment as well."
+                        );
+                      } else {
+                        navigate(
+                          page === "HOME" || page === "THE BIG MOUTH"
+                            ? "/"
+                            : page === "VIDEOHUB"
+                            ? "/videohub"
+                            : "#"
+                        );
+                      }
+                    }}
                     textAlign="center"
                   >
                     {page}
@@ -151,9 +171,23 @@ function NavBar() {
                 key={page}
                 onClick={() => {
                   handleCloseNavMenu();
-                  navigate(
-                    page === "HOME" || page === "THE BIG MOUTH" ? "/" : "#"
-                  );
+                  if (
+                    page === "ABOUT US" ||
+                    page === "THEATRE" ||
+                    page === "TBH MEANS BUSINESS"
+                  ) {
+                    alert(
+                      "This section is currently under development. Please take a look at THE BIG MOUTH, VIDEOHUB pages and the USER environment as well."
+                    );
+                  } else {
+                    navigate(
+                      page === "HOME" || page === "THE BIG MOUTH"
+                        ? "/"
+                        : page === "VIDEOHUB"
+                        ? "/videohub"
+                        : "#"
+                    );
+                  }
                 }}
                 sx={{
                   my: 2,
@@ -207,7 +241,13 @@ function NavBar() {
               color="inherit"
               sx={{ ml: 2, mr: 2 }}
             >
-              <SearchIcon />
+              <SearchIcon
+                onClick={() =>
+                  alert(
+                    "This section is currently under development. Please take a look at THE BIG MOUTH, VIDEOHUB pages and the USER environment as well."
+                  )
+                }
+              />
             </IconButton>
           </Box>
 


### PR DESCRIPTION
1. I temporarily changed "GET INVOLVED" to "USERHUB" in the navigation bar just for our presentation. This makes it look better and helps us show our project's features during the presentation. After Saturday's presentation, I'll put it back to how it was.
<img width="1279" alt="Screenshot 2023-12-03 at 20 05 11" src="https://github.com/JoeWeate/thebigmouth/assets/113059278/69e788eb-cf1f-4913-b86d-b7cd2dc1fb61">

2. I also added a "Dashboard" option in the user menu.

3. If someone tries to click on links that we haven't created yet, a popup alert will appear. It's just to let them know that these pages haven't been developed.
<img width="1279" alt="Screenshot 2023-12-03 at 20 09 01" src="https://github.com/JoeWeate/thebigmouth/assets/113059278/f703105b-e599-4b47-a72c-650c8f1947b5">
